### PR TITLE
Add NIcalc in Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,8 @@ Imports:
     sf,
     stringr,
     tmap
+Remotes:
+    NINAnor/NIcalc
 Depends: 
     R (>= 2.10)
 LazyData: true


### PR DESCRIPTION
I am not proficient in R, but my understanding is adding the NIcalc dependency under remotes makes the package installable, even when NIcalc has not been installed previously.